### PR TITLE
Feat/material3 fab menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -17,6 +17,7 @@
  ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -30,17 +31,20 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.FilterAlt
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonMenu
+import androidx.compose.material3.FloatingActionButtonMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
@@ -53,12 +57,14 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.ToggleFloatingActionButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -251,7 +257,7 @@ fun DeckPickerScreen(
     searchFocusRequester: androidx.compose.ui.focus.FocusRequester = androidx.compose.ui.focus.FocusRequester(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
-    var isFabMenuOpen by remember { mutableStateOf(false) }
+    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
     var isSearchOpen by remember { mutableStateOf(false) }
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
@@ -322,44 +328,54 @@ fun DeckPickerScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = { isFabMenuOpen = !isFabMenuOpen },
-                shape = MaterialTheme.shapes.extraLarge, // Apply expressive.
+            BackHandler(fabMenuExpanded) { fabMenuExpanded = false }
+
+            FloatingActionButtonMenu(
+                expanded = fabMenuExpanded,
+                button = {
+                    ToggleFloatingActionButton(
+                        checked = fabMenuExpanded,
+                        onCheckedChange = { fabMenuExpanded = !fabMenuExpanded },
+                    ) {
+                        Icon(
+                            imageVector = if (fabMenuExpanded) Icons.Filled.Close else Icons.Filled.Add,
+                            contentDescription = null,
+                        )
+                    }
+                },
             ) {
-                Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.add))
-                DropdownMenu(
-                    expanded = isFabMenuOpen,
-                    onDismissRequest = { isFabMenuOpen = false },
-                ) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.add_note)) },
-                        onClick = {
-                            onAddNote()
-                            isFabMenuOpen = false
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.new_deck)) },
-                        onClick = {
-                            onAddDeck()
-                            isFabMenuOpen = false
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.get_shared)) },
-                        onClick = {
-                            onAddSharedDeck()
-                            isFabMenuOpen = false
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.new_dynamic_deck)) },
-                        onClick = {
-                            onAddFilteredDeck()
-                            isFabMenuOpen = false
-                        },
-                    )
-                }
+                FloatingActionButtonMenuItem(
+                    onClick = {
+                        onAddNote()
+                        fabMenuExpanded = false
+                    },
+                    icon = { Icon(Icons.AutoMirrored.Filled.NoteAdd, contentDescription = null) },
+                    text = { Text(text = stringResource(R.string.add_note)) },
+                )
+                FloatingActionButtonMenuItem(
+                    onClick = {
+                        onAddDeck()
+                        fabMenuExpanded = false
+                    },
+                    icon = { Icon(Icons.Filled.CreateNewFolder, contentDescription = null) },
+                    text = { Text(text = stringResource(R.string.new_deck)) },
+                )
+                FloatingActionButtonMenuItem(
+                    onClick = {
+                        onAddSharedDeck()
+                        fabMenuExpanded = false
+                    },
+                    icon = { Icon(Icons.Filled.Download, contentDescription = null) },
+                    text = { Text(text = stringResource(R.string.get_shared)) },
+                )
+                FloatingActionButtonMenuItem(
+                    onClick = {
+                        onAddFilteredDeck()
+                        fabMenuExpanded = false
+                    },
+                    icon = { Icon(Icons.Filled.FilterAlt, contentDescription = null) },
+                    text = { Text(text = stringResource(R.string.new_dynamic_deck)) },
+                )
             }
         },
     ) { paddingValues ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -355,7 +355,7 @@ fun DeckPickerScreen(
                         }
                         .animateFloatingActionButton(
                             visible = fabVisible || fabMenuExpanded,
-                            alignment = Alignment.BottomStart,
+                            alignment = Alignment.BottomEnd,
                         )
                         .focusRequester(focusRequester),
                         checked = fabMenuExpanded,


### PR DESCRIPTION
This pull request refactors the floating action button (FAB) menu in the `DeckPickerScreen.kt` to use modern Material3 components, improving accessibility, code clarity, and user experience. The changes replace the previous FAB and dropdown menu approach with a more expressive and accessible FAB menu, add new icons, and optimize state management and visibility logic.

**Material3 FAB Menu Refactor:**
* Replaced legacy `FloatingActionButton` and `DropdownMenu` implementation with `FloatingActionButtonMenu` and `FloatingActionButtonMenuItem`, enhancing UI consistency and accessibility.
* Added new icons for menu actions (`NoteAdd`, `CreateNewFolder`, `Download`, `FilterAlt`) and improved menu item descriptions for better user understanding.

**State and Accessibility Improvements:**
* Improved FAB menu state management by switching from `isFabMenuOpen` to `fabMenuExpanded` with `rememberSaveable`, and added a `BackHandler` to close the menu on back press. [[1]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL251-R276) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL325-L363)
* Enhanced accessibility by adding semantics such as `traversalIndex`, `stateDescription`, and `contentDescription` to the FAB menu toggle.

**UI and Codebase Optimizations:**
* Updated alignment and focus handling by using `Alignment.TopCenter` and sharing `FocusRequester` instances. [[1]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL148-R165) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL251-R276)
* Streamlined imports by removing unused components and adding necessary ones for new features. [[1]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdR32-R48) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdR60-R91)