### PR TITLE
Use fabmenu tablet

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -57,7 +57,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.painter.Painter
@@ -348,12 +347,7 @@ fun AnkiDroidApp(
             }
             Scrim(
                 visible = fabMenuExpanded, onDismiss = { fabMenuExpanded = false })
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(end = 8.dp, bottom = 32.dp),
-                contentAlignment = Alignment.BottomEnd
-            ) {
+            ExpandableFabContainer {
                 ExpandableFab(
                     expanded = fabMenuExpanded,
                     onExpandedChange = { fabMenuExpanded = it },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.MoreVert
@@ -37,7 +36,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
@@ -161,7 +159,6 @@ fun AnkiDroidApp(
     if (fragmented) {
         var isSearchOpen by remember { mutableStateOf(false) }
         var isStudyOptionsMenuOpen by remember { mutableStateOf(false) }
-        var isFabMenuOpen by remember { mutableStateOf(false) }
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
         val listState = rememberLazyListState()
         // Tablet layout
@@ -313,45 +310,12 @@ fun AnkiDroidApp(
                 )
             },
             floatingActionButton = {
-                FloatingActionButton(
-                    onClick = { isFabMenuOpen = !isFabMenuOpen },
-                    shape = MaterialTheme.shapes.extraLarge, // Apply expressive shape
-                ) {
-                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.add))
-                    DropdownMenu(
-                        expanded = isFabMenuOpen,
-                        onDismissRequest = { isFabMenuOpen = false },
-                    ) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.add_card)) },
-                            onClick = {
-                                onAddNote()
-                                isFabMenuOpen = false
-                            },
-                        )
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.new_deck)) },
-                            onClick = {
-                                onAddDeck()
-                                isFabMenuOpen = false
-                            },
-                        )
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.get_shared)) },
-                            onClick = {
-                                onAddSharedDeck()
-                                isFabMenuOpen = false
-                            },
-                        )
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.new_dynamic_deck)) },
-                            onClick = {
-                                onAddFilteredDeck()
-                                isFabMenuOpen = false
-                            },
-                        )
-                    }
-                }
+                ExpandableFab(
+                    onAddNote = onAddNote,
+                    onAddDeck = onAddDeck,
+                    onAddSharedDeck = onAddSharedDeck,
+                    onAddFilteredDeck = onAddFilteredDeck
+                )
             },
         ) { paddingValues ->
             Row(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -17,6 +17,7 @@
  ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.expandVertically
@@ -291,104 +292,118 @@ fun DeckPickerScreen(
     onNavigationIconClick: () -> Unit,
     searchFocusRequester: FocusRequester = FocusRequester(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    fabMenuExpanded: Boolean,
+    onFabMenuExpandedChange: (Boolean) -> Unit
 ) {
     var isSearchOpen by remember { mutableStateOf(false) }
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val listState = rememberLazyListState()
 
-    Scaffold(
-        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        snackbarHost = {
-            SnackbarHost(snackbarHostState) { data ->
-                Snackbar(
-                    snackbarData = data,
-                    containerColor = MaterialTheme.colorScheme.secondary,
-                    contentColor = MaterialTheme.colorScheme.onSecondary,
-                    actionColor = MaterialTheme.colorScheme.primary,
-                    dismissActionContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
-        },
-        topBar = {
-            LargeTopAppBar(
-                title = {
-                    if (!isSearchOpen) Text(
-                        stringResource(R.string.app_name),
-                        style = MaterialTheme.typography.titleLarge
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+            snackbarHost = {
+                SnackbarHost(snackbarHostState) { data ->
+                    Snackbar(
+                        snackbarData = data,
+                        containerColor = MaterialTheme.colorScheme.secondary,
+                        contentColor = MaterialTheme.colorScheme.onSecondary,
+                        actionColor = MaterialTheme.colorScheme.primary,
+                        dismissActionContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                     )
-                }, // Expressive TopAppBar Title
-                navigationIcon = {
-                    IconButton(onClick = onNavigationIconClick) {
-                        Icon(
-                            Icons.Default.Menu,
-                            contentDescription = stringResource(R.string.navigation_drawer_open)
+                }
+            },
+            topBar = {
+                LargeTopAppBar(
+                    title = {
+                        if (!isSearchOpen) Text(
+                            stringResource(R.string.app_name),
+                            style = MaterialTheme.typography.titleLarge
                         )
-                    }
-                },
-                actions = {
-                    if (isSearchOpen) {
-                        TextField(
-                            value = searchQuery,
-                            onValueChange = onSearchQueryChanged,
-                            modifier = Modifier
-                                .weight(1f)
-                                .focusRequester(searchFocusRequester),
-                            placeholder = { Text(stringResource(R.string.search_decks)) },
-                            trailingIcon = {
-                                IconButton(onClick = {
-                                    onSearchQueryChanged("")
-                                    isSearchOpen = false
-                                }) {
-                                    Icon(
-                                        Icons.Default.Close,
-                                        contentDescription = stringResource(R.string.close)
-                                    )
-                                }
-                            },
-                        )
-                    } else {
-                        IconButton(onClick = { isSearchOpen = true }) {
+                    }, // Expressive TopAppBar Title
+                    navigationIcon = {
+                        IconButton(onClick = onNavigationIconClick) {
                             Icon(
-                                Icons.Default.Search,
-                                contentDescription = stringResource(R.string.search_decks)
+                                Icons.Default.Menu,
+                                contentDescription = stringResource(R.string.navigation_drawer_open)
                             )
                         }
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    scrolledContainerColor = MaterialTheme.colorScheme.surface,
-                    navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                ),
-                scrollBehavior = scrollBehavior,
+                    },
+                    actions = {
+                        if (isSearchOpen) {
+                            TextField(
+                                value = searchQuery,
+                                onValueChange = onSearchQueryChanged,
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .focusRequester(searchFocusRequester),
+                                placeholder = { Text(stringResource(R.string.search_decks)) },
+                                trailingIcon = {
+                                    IconButton(onClick = {
+                                        onSearchQueryChanged("")
+                                        isSearchOpen = false
+                                    }) {
+                                        Icon(
+                                            Icons.Default.Close,
+                                            contentDescription = stringResource(R.string.close)
+                                        )
+                                    }
+                                },
+                            )
+                        } else {
+                            IconButton(onClick = { isSearchOpen = true }) {
+                                Icon(
+                                    Icons.Default.Search,
+                                    contentDescription = stringResource(R.string.search_decks)
+                                )
+                            }
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        scrolledContainerColor = MaterialTheme.colorScheme.surface,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    ),
+                    scrollBehavior = scrollBehavior,
+                )
+            },
+        ) { paddingValues ->
+            DeckPickerContent(
+                decks = decks,
+                isRefreshing = isRefreshing,
+                onRefresh = onRefresh,
+                backgroundImage = backgroundImage,
+                onDeckClick = onDeckClick,
+                onExpandClick = onExpandClick,
+                onDeckOptions = onDeckOptions,
+                onRename = onRename,
+                onExport = onExport,
+                onDelete = onDelete,
+                onRebuild = onRebuild,
+                onEmpty = onEmpty,
+                listState = listState,
+                modifier = Modifier.padding(paddingValues)
             )
-        },
-        floatingActionButton = {
+        }
+        Scrim(
+            visible = fabMenuExpanded, onDismiss = { onFabMenuExpandedChange(false) })
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(end = 8.dp, bottom = 32.dp),
+            contentAlignment = Alignment.BottomEnd
+        ) {
             ExpandableFab(
+                expanded = fabMenuExpanded,
+                onExpandedChange = onFabMenuExpandedChange,
                 onAddNote = onAddNote,
                 onAddDeck = onAddDeck,
                 onAddSharedDeck = onAddSharedDeck,
                 onAddFilteredDeck = onAddFilteredDeck
             )
         }
-    ) { paddingValues ->
-        DeckPickerContent(
-            decks = decks,
-            isRefreshing = isRefreshing,
-            onRefresh = onRefresh,
-            backgroundImage = backgroundImage,
-            onDeckClick = onDeckClick,
-            onExpandClick = onExpandClick,
-            onDeckOptions = onDeckOptions,
-            onRename = onRename,
-            onExport = onExport,
-            onDelete = onDelete,
-            onRebuild = onRebuild,
-            onEmpty = onEmpty,
-            listState = listState,
-            modifier = Modifier.padding(paddingValues)
-        )
+        BackHandler(fabMenuExpanded) { onFabMenuExpandedChange(false) }
     }
 }
 
@@ -434,5 +449,7 @@ fun DeckPickerScreenPreview() {
         onDelete = {},
         onRebuild = {},
         onEmpty = {},
-        onNavigationIconClick = {})
+        onNavigationIconClick = {},
+        fabMenuExpanded = false,
+        onFabMenuExpandedChange = {})
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -388,12 +388,7 @@ fun DeckPickerScreen(
         }
         Scrim(
             visible = fabMenuExpanded, onDismiss = { onFabMenuExpandedChange(false) })
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(end = 8.dp, bottom = 32.dp),
-            contentAlignment = Alignment.BottomEnd
-        ) {
+        ExpandableFabContainer {
             ExpandableFab(
                 expanded = fabMenuExpanded,
                 onExpandedChange = onFabMenuExpandedChange,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -17,19 +17,14 @@
  ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -44,17 +39,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FloatingActionButtonMenu
-import androidx.compose.material3.FloatingActionButtonMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
@@ -67,18 +58,13 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.material3.ToggleFloatingActionButton
-import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.animateFloatingActionButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -86,21 +72,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -313,203 +292,103 @@ fun DeckPickerScreen(
     searchFocusRequester: FocusRequester = FocusRequester(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
-    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
     var isSearchOpen by remember { mutableStateOf(false) }
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val listState = rememberLazyListState()
-    val fabVisible by remember { derivedStateOf { listState.firstVisibleItemIndex == 0 } }
-    val focusRequester = remember { FocusRequester() }
-    val scrimColor by animateColorAsState(
-        targetValue = if (fabMenuExpanded) MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f) else Color.Transparent,
-        animationSpec = tween(500),
-        label = "Scrim"
-    )
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        Scaffold(
-            modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-            snackbarHost = {
-                SnackbarHost(snackbarHostState) { data ->
-                    Snackbar(
-                        snackbarData = data,
-                        containerColor = MaterialTheme.colorScheme.secondary,
-                        contentColor = MaterialTheme.colorScheme.onSecondary,
-                        actionColor = MaterialTheme.colorScheme.primary,
-                        dismissActionContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
-                }
-            },
-            topBar = {
-                LargeTopAppBar(
-                    title = {
-                        if (!isSearchOpen) Text(
-                            stringResource(R.string.app_name),
-                            style = MaterialTheme.typography.titleLarge
-                        )
-                    }, // Expressive TopAppBar Title
-                    navigationIcon = {
-                        IconButton(onClick = onNavigationIconClick) {
-                            Icon(
-                                Icons.Default.Menu,
-                                contentDescription = stringResource(R.string.navigation_drawer_open)
-                            )
-                        }
-                    },
-                    actions = {
-                        if (isSearchOpen) {
-                            TextField(
-                                value = searchQuery,
-                                onValueChange = onSearchQueryChanged,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .focusRequester(searchFocusRequester),
-                                placeholder = { Text(stringResource(R.string.search_decks)) },
-                                trailingIcon = {
-                                    IconButton(onClick = {
-                                        onSearchQueryChanged("")
-                                        isSearchOpen = false
-                                    }) {
-                                        Icon(
-                                            Icons.Default.Close,
-                                            contentDescription = stringResource(R.string.close)
-                                        )
-                                    }
-                                },
-                            )
-                        } else {
-                            IconButton(onClick = { isSearchOpen = true }) {
-                                Icon(
-                                    Icons.Default.Search,
-                                    contentDescription = stringResource(R.string.search_decks)
-                                )
-                            }
-                        }
-                    },
-                    colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
-                        scrolledContainerColor = MaterialTheme.colorScheme.surface,
-                        navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    ),
-                    scrollBehavior = scrollBehavior,
+    Scaffold(
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        snackbarHost = {
+            SnackbarHost(snackbarHostState) { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = MaterialTheme.colorScheme.secondary,
+                    contentColor = MaterialTheme.colorScheme.onSecondary,
+                    actionColor = MaterialTheme.colorScheme.primary,
+                    dismissActionContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-            },
-        ) { paddingValues ->
-            DeckPickerContent(
-                decks = decks,
-                isRefreshing = isRefreshing,
-                onRefresh = onRefresh,
-                backgroundImage = backgroundImage,
-                onDeckClick = onDeckClick,
-                onExpandClick = onExpandClick,
-                onDeckOptions = onDeckOptions,
-                onRename = onRename,
-                onExport = onExport,
-                onDelete = onDelete,
-                onRebuild = onRebuild,
-                onEmpty = onEmpty,
-                listState = listState,
-                modifier = Modifier.padding(paddingValues)
-            )
-        }
-        if (fabMenuExpanded) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(scrimColor)
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = { fabMenuExpanded = false })
-            )
-        }
-        BackHandler(fabMenuExpanded) { fabMenuExpanded = false }
-
-        val onMenuItemClick = { action: () -> Unit ->
-            {
-                action()
-                fabMenuExpanded = false
             }
-        }
-
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(end = 8.dp, bottom = 32.dp),
-            contentAlignment = Alignment.BottomEnd
-        ) {
-            FloatingActionButtonMenu(
-                expanded = fabMenuExpanded,
-                button = {
-                    val fabMenuExpandedStateDescription = stringResource(R.string.fab_menu_expanded)
-                    val fabMenuCollapsedStateDescription =
-                        stringResource(R.string.fab_menu_collapsed)
-                    val fabMenuToggleContentDescription = stringResource(R.string.fab_menu_toggle)
-                    ToggleFloatingActionButton(modifier = Modifier
-                        .semantics {
-                            traversalIndex = -1f
-                            stateDescription =
-                                if (fabMenuExpanded) fabMenuExpandedStateDescription else fabMenuCollapsedStateDescription
-                            contentDescription = fabMenuToggleContentDescription
-                        }
-                        .animateFloatingActionButton(
-                            visible = fabVisible || fabMenuExpanded,
-                            alignment = Alignment.BottomEnd,
-                        )
-                        .focusRequester(focusRequester),
-                        checked = fabMenuExpanded,
-                        onCheckedChange = { fabMenuExpanded = !fabMenuExpanded }) {
-                        val imageVector by remember {
-                            derivedStateOf {
-                                if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.Add
-                            }
-                        }
+        },
+        topBar = {
+            LargeTopAppBar(
+                title = {
+                    if (!isSearchOpen) Text(
+                        stringResource(R.string.app_name),
+                        style = MaterialTheme.typography.titleLarge
+                    )
+                }, // Expressive TopAppBar Title
+                navigationIcon = {
+                    IconButton(onClick = onNavigationIconClick) {
                         Icon(
-                            painter = rememberVectorPainter(imageVector),
-                            contentDescription = null,
-                            modifier = Modifier.animateIcon({ checkedProgress }),
+                            Icons.Default.Menu,
+                            contentDescription = stringResource(R.string.navigation_drawer_open)
                         )
                     }
                 },
-            ) {
-                FloatingActionButtonMenuItem(
-                    onClick = onMenuItemClick(onAddSharedDeck),
-                    icon = { Icon(Icons.Filled.Download, contentDescription = null) },
-                    text = { Text(text = stringResource(R.string.get_shared)) },
-                )
-                FloatingActionButtonMenuItem(
-                    onClick = onMenuItemClick(onAddFilteredDeck),
-                    icon = {
-                        Icon(
-                            painterResource(id = R.drawable.ic_add_filtered_deck),
-                            contentDescription = null
+                actions = {
+                    if (isSearchOpen) {
+                        TextField(
+                            value = searchQuery,
+                            onValueChange = onSearchQueryChanged,
+                            modifier = Modifier
+                                .weight(1f)
+                                .focusRequester(searchFocusRequester),
+                            placeholder = { Text(stringResource(R.string.search_decks)) },
+                            trailingIcon = {
+                                IconButton(onClick = {
+                                    onSearchQueryChanged("")
+                                    isSearchOpen = false
+                                }) {
+                                    Icon(
+                                        Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.close)
+                                    )
+                                }
+                            },
                         )
-                    },
-                    text = { Text(text = stringResource(R.string.new_dynamic_deck)) },
-                )
-                FloatingActionButtonMenuItem(
-                    onClick = onMenuItemClick(onAddDeck),
-                    icon = {
-                        Icon(
-                            painterResource(id = R.drawable.ic_add_deck_filled),
-                            contentDescription = null
-                        )
-                    },
-                    text = { Text(text = stringResource(R.string.new_deck)) },
-                )
-                FloatingActionButtonMenuItem(
-                    onClick = onMenuItemClick(onAddNote),
-                    icon = {
-                        Icon(
-                            painterResource(id = R.drawable.ic_add_note),
-                            contentDescription = null
-                        )
-                    },
-                    text = { Text(text = stringResource(R.string.add_card)) },
-                )
-            }
-
+                    } else {
+                        IconButton(onClick = { isSearchOpen = true }) {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription = stringResource(R.string.search_decks)
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surface,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        floatingActionButton = {
+            ExpandableFab(
+                onAddNote = onAddNote,
+                onAddDeck = onAddDeck,
+                onAddSharedDeck = onAddSharedDeck,
+                onAddFilteredDeck = onAddFilteredDeck
+            )
         }
+    ) { paddingValues ->
+        DeckPickerContent(
+            decks = decks,
+            isRefreshing = isRefreshing,
+            onRefresh = onRefresh,
+            backgroundImage = backgroundImage,
+            onDeckClick = onDeckClick,
+            onExpandClick = onExpandClick,
+            onDeckOptions = onDeckOptions,
+            onRename = onRename,
+            onExport = onExport,
+            onDelete = onDelete,
+            onRebuild = onRebuild,
+            onEmpty = onEmpty,
+            listState = listState,
+            modifier = Modifier.padding(paddingValues)
+        )
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Dimens.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Dimens.kt
@@ -17,38 +17,7 @@
  ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
-@Composable
-fun Scrim(
-    visible: Boolean, onDismiss: () -> Unit
-) {
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(animationSpec = tween(500)),
-        exit = fadeOut(animationSpec = tween(500))
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f))
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onDismiss
-                )
-        )
-    }
-}
+internal val FabPaddingEnd = 8.dp
+internal val FabPaddingBottom = 32.dp

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
@@ -1,27 +1,41 @@
+/****************************************************************************************
+ * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
-import androidx.activity.compose.BackHandler
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
-import androidx.compose.material3.*
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingActionButtonMenu
+import androidx.compose.material3.FloatingActionButtonMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleFloatingActionButton
 import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
-import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -29,116 +43,87 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.traversalIndex
-import androidx.compose.ui.unit.dp
 import com.ichi2.anki.R
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ExpandableFab(
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
     onAddNote: () -> Unit,
     onAddDeck: () -> Unit,
     onAddSharedDeck: () -> Unit,
-    onAddFilteredDeck: () -> Unit,
+    onAddFilteredDeck: () -> Unit
 ) {
-    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
-    val scrimColor by animateColorAsState(
-        targetValue = if (fabMenuExpanded) MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f) else Color.Transparent,
-        animationSpec = tween(500),
-        label = "Scrim"
-    )
-
-    if (fabMenuExpanded) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(scrimColor)
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = { fabMenuExpanded = false })
-        )
-    }
-    BackHandler(fabMenuExpanded) { fabMenuExpanded = false }
 
     val onMenuItemClick = { action: () -> Unit ->
         {
             action()
-            fabMenuExpanded = false
+            onExpandedChange(false)
         }
     }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(end = 8.dp, bottom = 32.dp),
-        contentAlignment = Alignment.BottomEnd
-    ) {
-        FloatingActionButtonMenu(
-            expanded = fabMenuExpanded,
-            button = {
-                val fabMenuExpandedStateDescription = stringResource(R.string.fab_menu_expanded)
-                val fabMenuCollapsedStateDescription =
-                    stringResource(R.string.fab_menu_collapsed)
-                val fabMenuToggleContentDescription = stringResource(R.string.fab_menu_toggle)
-                ToggleFloatingActionButton(modifier = Modifier
-                    .semantics {
-                        traversalIndex = -1f
-                        stateDescription =
-                            if (fabMenuExpanded) fabMenuExpandedStateDescription else fabMenuCollapsedStateDescription
-                        contentDescription = fabMenuToggleContentDescription
-                    }
-                    .focusRequester(focusRequester),
-                    checked = fabMenuExpanded,
-                    onCheckedChange = { fabMenuExpanded = !fabMenuExpanded }) {
-                    val imageVector by remember {
-                        derivedStateOf {
-                            if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.Add
-                        }
-                    }
-                    Icon(
-                        painter = rememberVectorPainter(imageVector),
-                        contentDescription = null,
-                        modifier = Modifier.animateIcon({ checkedProgress }),
-                    )
+    FloatingActionButtonMenu(
+        expanded = expanded,
+        button = {
+            val fabMenuExpandedStateDescription = stringResource(R.string.fab_menu_expanded)
+            val fabMenuCollapsedStateDescription = stringResource(R.string.fab_menu_collapsed)
+            val fabMenuToggleContentDescription = stringResource(R.string.fab_menu_toggle)
+            ToggleFloatingActionButton(modifier = Modifier
+                .semantics {
+                    traversalIndex = -1f
+                    stateDescription =
+                        if (expanded) fabMenuExpandedStateDescription else fabMenuCollapsedStateDescription
+                    contentDescription = fabMenuToggleContentDescription
                 }
+                .focusRequester(focusRequester),
+                checked = expanded,
+                onCheckedChange = { onExpandedChange(!expanded) }) {
+                val imageVector by remember {
+                    derivedStateOf {
+                        if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.Add
+                    }
+                }
+                Icon(
+                    painter = rememberVectorPainter(imageVector),
+                    contentDescription = null,
+                    modifier = Modifier.animateIcon({ checkedProgress }),
+                )
+            }
+        },
+    ) {
+        FloatingActionButtonMenuItem(
+            onClick = onMenuItemClick(onAddSharedDeck),
+            icon = { Icon(Icons.Filled.Download, contentDescription = null) },
+            text = { Text(text = stringResource(R.string.get_shared)) },
+        )
+        FloatingActionButtonMenuItem(
+            onClick = onMenuItemClick(onAddFilteredDeck),
+            icon = {
+                Icon(
+                    painterResource(id = R.drawable.ic_add_filtered_deck), contentDescription = null
+                )
             },
-        ) {
-            FloatingActionButtonMenuItem(
-                onClick = onMenuItemClick(onAddSharedDeck),
-                icon = { Icon(Icons.Filled.Download, contentDescription = null) },
-                text = { Text(text = stringResource(R.string.get_shared)) },
-            )
-            FloatingActionButtonMenuItem(
-                onClick = onMenuItemClick(onAddFilteredDeck),
-                icon = {
-                    Icon(
-                        painterResource(id = R.drawable.ic_add_filtered_deck),
-                        contentDescription = null
-                    )
-                },
-                text = { Text(text = stringResource(R.string.new_dynamic_deck)) },
-            )
-            FloatingActionButtonMenuItem(
-                onClick = onMenuItemClick(onAddDeck),
-                icon = {
-                    Icon(
-                        painterResource(id = R.drawable.ic_add_deck_filled),
-                        contentDescription = null
-                    )
-                },
-                text = { Text(text = stringResource(R.string.new_deck)) },
-            )
-            FloatingActionButtonMenuItem(
-                onClick = onMenuItemClick(onAddNote),
-                icon = {
-                    Icon(
-                        painterResource(id = R.drawable.ic_add_note),
-                        contentDescription = null
-                    )
-                },
-                text = { Text(text = stringResource(R.string.add_card)) },
-            )
-        }
+            text = { Text(text = stringResource(R.string.new_dynamic_deck)) },
+        )
+        FloatingActionButtonMenuItem(
+            onClick = onMenuItemClick(onAddDeck),
+            icon = {
+                Icon(
+                    painterResource(id = R.drawable.ic_add_deck_filled), contentDescription = null
+                )
+            },
+            text = { Text(text = stringResource(R.string.new_deck)) },
+        )
+        FloatingActionButtonMenuItem(
+            onClick = onMenuItemClick(onAddNote),
+            icon = {
+                Icon(
+                    painterResource(id = R.drawable.ic_add_note), contentDescription = null
+                )
+            },
+            text = { Text(text = stringResource(R.string.add_card)) },
+        )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
@@ -79,7 +79,7 @@ fun ExpandableFab(
                 }
                 .focusRequester(focusRequester),
                 checked = expanded,
-                onCheckedChange = { onExpandedChange(!expanded) }) {
+                onCheckedChange = { onExpandedChange(it) }) {
                 val imageVector by remember {
                     derivedStateOf {
                         if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.Add

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
@@ -1,0 +1,144 @@
+package com.ichi2.anki.ui.compose
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.*
+import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.traversalIndex
+import androidx.compose.ui.unit.dp
+import com.ichi2.anki.R
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ExpandableFab(
+    onAddNote: () -> Unit,
+    onAddDeck: () -> Unit,
+    onAddSharedDeck: () -> Unit,
+    onAddFilteredDeck: () -> Unit,
+) {
+    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+    val scrimColor by animateColorAsState(
+        targetValue = if (fabMenuExpanded) MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f) else Color.Transparent,
+        animationSpec = tween(500),
+        label = "Scrim"
+    )
+
+    if (fabMenuExpanded) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(scrimColor)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = { fabMenuExpanded = false })
+        )
+    }
+    BackHandler(fabMenuExpanded) { fabMenuExpanded = false }
+
+    val onMenuItemClick = { action: () -> Unit ->
+        {
+            action()
+            fabMenuExpanded = false
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(end = 8.dp, bottom = 32.dp),
+        contentAlignment = Alignment.BottomEnd
+    ) {
+        FloatingActionButtonMenu(
+            expanded = fabMenuExpanded,
+            button = {
+                val fabMenuExpandedStateDescription = stringResource(R.string.fab_menu_expanded)
+                val fabMenuCollapsedStateDescription =
+                    stringResource(R.string.fab_menu_collapsed)
+                val fabMenuToggleContentDescription = stringResource(R.string.fab_menu_toggle)
+                ToggleFloatingActionButton(modifier = Modifier
+                    .semantics {
+                        traversalIndex = -1f
+                        stateDescription =
+                            if (fabMenuExpanded) fabMenuExpandedStateDescription else fabMenuCollapsedStateDescription
+                        contentDescription = fabMenuToggleContentDescription
+                    }
+                    .focusRequester(focusRequester),
+                    checked = fabMenuExpanded,
+                    onCheckedChange = { fabMenuExpanded = !fabMenuExpanded }) {
+                    val imageVector by remember {
+                        derivedStateOf {
+                            if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.Add
+                        }
+                    }
+                    Icon(
+                        painter = rememberVectorPainter(imageVector),
+                        contentDescription = null,
+                        modifier = Modifier.animateIcon({ checkedProgress }),
+                    )
+                }
+            },
+        ) {
+            FloatingActionButtonMenuItem(
+                onClick = onMenuItemClick(onAddSharedDeck),
+                icon = { Icon(Icons.Filled.Download, contentDescription = null) },
+                text = { Text(text = stringResource(R.string.get_shared)) },
+            )
+            FloatingActionButtonMenuItem(
+                onClick = onMenuItemClick(onAddFilteredDeck),
+                icon = {
+                    Icon(
+                        painterResource(id = R.drawable.ic_add_filtered_deck),
+                        contentDescription = null
+                    )
+                },
+                text = { Text(text = stringResource(R.string.new_dynamic_deck)) },
+            )
+            FloatingActionButtonMenuItem(
+                onClick = onMenuItemClick(onAddDeck),
+                icon = {
+                    Icon(
+                        painterResource(id = R.drawable.ic_add_deck_filled),
+                        contentDescription = null
+                    )
+                },
+                text = { Text(text = stringResource(R.string.new_deck)) },
+            )
+            FloatingActionButtonMenuItem(
+                onClick = onMenuItemClick(onAddNote),
+                icon = {
+                    Icon(
+                        painterResource(id = R.drawable.ic_add_note),
+                        contentDescription = null
+                    )
+                },
+                text = { Text(text = stringResource(R.string.add_card)) },
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFabContainer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFabContainer.kt
@@ -17,38 +17,23 @@
  ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun Scrim(
-    visible: Boolean, onDismiss: () -> Unit
+fun ExpandableFabContainer(
+    content: @Composable () -> Unit
 ) {
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(animationSpec = tween(500)),
-        exit = fadeOut(animationSpec = tween(500))
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(end = FabPaddingEnd, bottom = FabPaddingBottom),
+        contentAlignment = Alignment.BottomEnd
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f))
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onDismiss
-                )
-        )
+        content()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Scrim.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Scrim.kt
@@ -1,0 +1,56 @@
+/****************************************************************************************
+ * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.ui.compose
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun Scrim(
+    visible: Boolean, onDismiss: () -> Unit
+) {
+    val scrimColor by animateColorAsState(
+        targetValue = if (visible) MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f) else Color.Transparent,
+        animationSpec = tween(500),
+        label = "Scrim"
+    )
+
+    if (visible) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(scrimColor)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onDismiss
+                )
+        )
+    }
+}


### PR DESCRIPTION
This pull request refactors the Floating Action Button (FAB) menu implementation in both the tablet and phone layouts of the AnkiDroid app, replacing the previous `FloatingActionButtonMenu` with a new `ExpandableFab` component and improving state management and code consistency. The changes also introduce a reusable `Scrim` overlay and streamline the handling of FAB menu expansion across device types.

**FAB Menu Refactor and Consistency Improvements:**

* Replaced the previous FAB menu implementation (`FloatingActionButtonMenu` and related items) with a new `ExpandableFab` component for both tablet and phone layouts, providing a unified and more maintainable approach to the FAB menu UI. [[1]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928L315-L355) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL415-R406)
* Centralized FAB menu state management using a single `fabMenuExpanded` variable (with `rememberSaveable` for tablets and passed as a parameter for phones), ensuring consistent expansion/collapse behavior across layouts. [[1]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928R154) [[2]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928L164-R169) [[3]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdR295-L326)
* Added a reusable `Scrim` overlay component that appears when the FAB menu is expanded, improving user experience by visually indicating modal state and handling dismissal. [[1]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928R349-R367) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL415-R406)
* Updated the back button handling to use `BackHandler` for closing the FAB menu, providing a consistent way for users to dismiss the menu on both layouts. [[1]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928R349-R367) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL415-R406)
* Cleaned up unused imports and removed legacy FAB menu-related code, simplifying the codebase and reducing maintenance overhead. [[1]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928R20-L27) [[2]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928L40) [[3]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928R58-R60) [[4]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL22-L32) [[5]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL47-L57) [[6]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL70-L103)

These changes improve code clarity, maintainability, and provide a better, more consistent user experience for interacting with the FAB menu.