### PR TITLE
Fix compose UI suggestions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -351,7 +351,7 @@ fun AnkiDroidApp(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(end = 8.dp, bottom = 32.dp),
+                    .padding(end = 16.dp, bottom = 16.dp),
                 contentAlignment = Alignment.BottomEnd
             ) {
                 ExpandableFab(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -72,6 +72,9 @@ import androidx.compose.ui.unit.sp
 import com.ichi2.anki.R
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 
+private val FabPaddingEnd = 8.dp
+private val FabPaddingBottom = 32.dp
+
 // Define Expressive Typography
 val AppTypography = Typography(
     displayLarge = TextStyle(
@@ -351,7 +354,7 @@ fun AnkiDroidApp(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(end = 16.dp, bottom = 16.dp),
+                    .padding(end = FabPaddingEnd, bottom = FabPaddingBottom),
                 contentAlignment = Alignment.BottomEnd
             ) {
                 ExpandableFab(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -57,7 +57,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.painter.Painter
@@ -71,9 +70,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ichi2.anki.R
 import com.ichi2.anki.deckpicker.DisplayDeckNode
-
-private val FabPaddingEnd = 8.dp
-private val FabPaddingBottom = 32.dp
 
 // Define Expressive Typography
 val AppTypography = Typography(
@@ -351,12 +347,7 @@ fun AnkiDroidApp(
             }
             Scrim(
                 visible = fabMenuExpanded, onDismiss = { fabMenuExpanded = false })
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(end = FabPaddingEnd, bottom = FabPaddingBottom),
-                contentAlignment = Alignment.BottomEnd
-            ) {
+            ExpandableFabContainer {
                 ExpandableFab(
                     expanded = fabMenuExpanded,
                     onExpandedChange = { fabMenuExpanded = it },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -92,6 +92,8 @@ import com.ichi2.anki.deckpicker.DisplayDeckNode
 
 private val expandedDeckCardRadius = 24.dp
 private val collapsedDeckCardRadius = 70.dp
+private val FabPaddingEnd = 8.dp
+private val FabPaddingBottom = 32.dp
 
 private class MorphShape(
     private val morph: Morph, private val percentage: Float
@@ -391,7 +393,7 @@ fun DeckPickerScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(end = 16.dp, bottom = 16.dp),
+                .padding(end = FabPaddingEnd, bottom = FabPaddingBottom),
             contentAlignment = Alignment.BottomEnd
         ) {
             ExpandableFab(
@@ -416,6 +418,7 @@ fun DeckPickerContentPreview() {
         onRefresh = {},
         backgroundImage = null,
         onDeckClick = {},
+        .
         onExpandClick = {},
         onDeckOptions = {},
         onRename = {},

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -391,7 +391,7 @@ fun DeckPickerScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(end = 8.dp, bottom = 32.dp),
+                .padding(end = 16.dp, bottom = 16.dp),
             contentAlignment = Alignment.BottomEnd
         ) {
             ExpandableFab(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -92,8 +92,6 @@ import com.ichi2.anki.deckpicker.DisplayDeckNode
 
 private val expandedDeckCardRadius = 24.dp
 private val collapsedDeckCardRadius = 70.dp
-private val FabPaddingEnd = 8.dp
-private val FabPaddingBottom = 32.dp
 
 private class MorphShape(
     private val morph: Morph, private val percentage: Float
@@ -390,12 +388,7 @@ fun DeckPickerScreen(
         }
         Scrim(
             visible = fabMenuExpanded, onDismiss = { onFabMenuExpandedChange(false) })
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(end = FabPaddingEnd, bottom = FabPaddingBottom),
-            contentAlignment = Alignment.BottomEnd
-        ) {
+        ExpandableFabContainer {
             ExpandableFab(
                 expanded = fabMenuExpanded,
                 onExpandedChange = onFabMenuExpandedChange,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -418,7 +418,6 @@ fun DeckPickerContentPreview() {
         onRefresh = {},
         backgroundImage = null,
         onDeckClick = {},
-        .
         onExpandClick = {},
         onDeckOptions = {},
         onRename = {},

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Dimens.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Dimens.kt
@@ -1,0 +1,23 @@
+/****************************************************************************************
+ * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.ui.compose
+
+import androidx.compose.ui.unit.dp
+
+internal val FabPaddingEnd = 8.dp
+internal val FabPaddingBottom = 32.dp

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFab.kt
@@ -79,7 +79,7 @@ fun ExpandableFab(
                 }
                 .focusRequester(focusRequester),
                 checked = expanded,
-                onCheckedChange = { onExpandedChange(!expanded) }) {
+                onCheckedChange = { onExpandedChange(it) }) {
                 val imageVector by remember {
                     derivedStateOf {
                         if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.Add

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFabContainer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/ExpandableFabContainer.kt
@@ -1,0 +1,39 @@
+/****************************************************************************************
+ * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.ui.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ExpandableFabContainer(
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(end = FabPaddingEnd, bottom = FabPaddingBottom),
+        contentAlignment = Alignment.BottomEnd
+    ) {
+        content()
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Scrim.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/Scrim.kt
@@ -17,8 +17,10 @@
  ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
-import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -26,26 +28,22 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 
 @Composable
 fun Scrim(
     visible: Boolean, onDismiss: () -> Unit
 ) {
-    val scrimColor by animateColorAsState(
-        targetValue = if (visible) MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f) else Color.Transparent,
-        animationSpec = tween(500),
-        label = "Scrim"
-    )
-
-    if (visible) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(animationSpec = tween(500)),
+        exit = fadeOut(animationSpec = tween(500))
+    ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(scrimColor)
+                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,


### PR DESCRIPTION
This pull request refactors the handling of FAB (Floating Action Button) padding and improves UI animation for scrims, along with a minor fix in the FAB expansion logic. The main changes focus on increasing code reusability and maintainability by centralizing padding values, enhancing animation smoothness, and correcting the behavior of the expandable FAB.

**UI consistency and maintainability**
* Centralized FAB padding values by introducing `FabPaddingEnd` and `FabPaddingBottom` constants in both `AnkiDroidApp.kt` and `DeckPickerScreen.kt`, replacing hardcoded values in `Box` modifiers. [[1]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928R75-R77) [[2]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928L354-R357) [[3]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdR95-R96) [[4]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL394-R396)

**Animation and interaction improvements**
* Refactored the `Scrim` composable to use `AnimatedVisibility` with `fadeIn` and `fadeOut` animations instead of manually animating color transparency, resulting in smoother appearance/disappearance transitions.

**Behavior fixes**
* Fixed the expandable FAB toggle logic by updating the `onCheckedChange` callback to use the provided value directly, ensuring correct expansion/collapse behavior.