### PR TITLE
Add rounded font

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -74,7 +74,7 @@ import com.ichi2.anki.deckpicker.DisplayDeckNode
 
 // Define Expressive Typography
 val GoogleSansRounded = FontFamily(
-    Font(R.font.google_sans_rounded_regular, FontWeight.Normal)
+    Font(R.font.google_sans_rounded_regular, FontWeight.Normal),
 )
 
 val AppTypography = Typography(
@@ -83,30 +83,106 @@ val AppTypography = Typography(
         fontWeight = FontWeight.Bold,
         fontSize = 57.sp,
         lineHeight = 64.sp,
-        letterSpacing = (-0.25).sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Bold,
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+        letterSpacing = 0.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Bold,
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+        letterSpacing = 0.sp
     ),
     headlineLarge = TextStyle(
         fontFamily = GoogleSansRounded,
         fontWeight = FontWeight.SemiBold,
         fontSize = 32.sp,
         lineHeight = 40.sp,
-        letterSpacing = 0.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
     ),
     titleLarge = TextStyle(
         fontFamily = GoogleSansRounded,
         fontWeight = FontWeight.Medium,
-        fontSize = 24.sp,
+        fontSize = 22.sp,
         lineHeight = 28.sp,
-        letterSpacing = 0.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
     ),
     bodyLarge = TextStyle(
         fontFamily = GoogleSansRounded,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
-        letterSpacing = 0.5.sp,
+        letterSpacing = 0.5.sp
     ),
-    // Add other text styles as needed, inheriting from M3 defaults or customizing
+    bodyMedium = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = GoogleSansRounded,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
 )
 
 // Define Expressive Shapes
@@ -187,9 +263,9 @@ fun AnkiDroidApp(
                         title = {
                             if (!isSearchOpen) Text(
                                 stringResource(R.string.app_name),
-                                style = MaterialTheme.typography.titleLarge
+                                style = MaterialTheme.typography.headlineSmall
                             )
-                        }, // Expressive TopAppBar Title
+                        },
                         navigationIcon = {
                             IconButton(onClick = onNavigationIconClick) {
                                 Icon(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -72,30 +73,34 @@ import com.ichi2.anki.R
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 
 // Define Expressive Typography
+val GoogleSansRounded = FontFamily(
+    Font(R.font.google_sans_rounded_regular, FontWeight.Normal)
+)
+
 val AppTypography = Typography(
     displayLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = GoogleSansRounded,
         fontWeight = FontWeight.Bold,
         fontSize = 57.sp,
         lineHeight = 64.sp,
         letterSpacing = (-0.25).sp,
     ),
     headlineLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = GoogleSansRounded,
         fontWeight = FontWeight.SemiBold,
         fontSize = 32.sp,
         lineHeight = 40.sp,
         letterSpacing = 0.sp,
     ),
     titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = GoogleSansRounded,
         fontWeight = FontWeight.Medium,
         fontSize = 24.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp,
     ),
     bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = GoogleSansRounded,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -92,19 +92,19 @@ fun DeckItem(
                 text = deck.newCount.toString(),
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(horizontal = 4.dp),
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodyLarge,
             )
             Text(
                 text = deck.lrnCount.toString(),
                 color = MaterialTheme.colorScheme.error,
                 modifier = Modifier.padding(horizontal = 4.dp),
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodyLarge,
             )
             Text(
                 text = deck.revCount.toString(),
                 color = Color(0xFF006400),
                 modifier = Modifier.padding(horizontal = 4.dp),
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodyLarge,
             )
             if (deck.canCollapse) {
                 Surface(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -318,9 +318,9 @@ fun DeckPickerScreen(
                     title = {
                         if (!isSearchOpen) Text(
                             stringResource(R.string.app_name),
-                            style = MaterialTheme.typography.titleLarge
+                            style = MaterialTheme.typography.headlineSmall
                         )
-                    }, // Expressive TopAppBar Title
+                    },
                     navigationIcon = {
                         IconButton(onClick = onNavigationIconClick) {
                             Icon(


### PR DESCRIPTION
This pull request updates the app’s typography system to use the `GoogleSansRounded` font family across all text styles and expands the set of defined styles for a more expressive and consistent UI. It also updates usages of text styles in key UI components to match the new typography definitions.

**Typography system overhaul:**

* Introduced a new `GoogleSansRounded` font family using `R.font.google_sans_rounded_regular` and applied it to all text styles in the `AppTypography` definition within `AnkiDroidApp.kt`. The typography now includes a full set of Material 3 text styles (display, headline, title, body, label) with customized weights, sizes, and letter spacing.
* Added the necessary import for the `Font` class to support custom font usage in Compose.

**UI component updates:**

* Changed the TopAppBar title style from `titleLarge` to `headlineSmall` in both `AnkiDroidApp.kt` and `DeckPickerScreen.kt` for better visual hierarchy and consistency with the new typography. [[1]](diffhunk://#diff-dea9ce5a882461737c1079a73de8d1512cf097fa6d6f6c7cc078255044394928L185-R268) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL321-R323)
* Updated the deck count text styles in `DeckItem.kt` from `bodyMedium` to `bodyLarge` to improve readability and align with the new typography system.