### PR TITLE
Fix: Apply dynamic theming to Reviewer UI

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -104,6 +104,7 @@ import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.flag
@@ -213,7 +214,7 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
         }
 
         composeView.setContent {
-            com.ichi2.anki.ui.compose.theme.AnkiDroidTheme {
+            AnkiDroidTheme {
                 com.ichi2.anki.reviewer.compose.ReviewerContent(viewModel)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -15,9 +15,15 @@
  */
 package com.ichi2.anki.reviewer.compose
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -72,12 +78,9 @@ fun AnswerButtons(
     }
 }
 
-import androidx.compose.material3.MaterialTheme
-
 @Composable
 fun ShowAnswerButton(
-    onShowAnswer: () -> Unit,
-    modifier: Modifier = Modifier
+    onShowAnswer: () -> Unit, modifier: Modifier = Modifier
 ) {
     Button(
         onClick = onShowAnswer,
@@ -103,8 +106,7 @@ fun EaseButtons(
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         EaseButton(
             label = "Again",
@@ -151,12 +153,8 @@ fun EaseButton(
     modifier: Modifier = Modifier
 ) {
     Button(
-        onClick = onClick,
-        modifier = modifier
-            .height(64.dp),
-        colors = ButtonDefaults.buttonColors(
-            containerColor = containerColor,
-            contentColor = contentColor
+        onClick = onClick, modifier = modifier.height(64.dp), colors = ButtonDefaults.buttonColors(
+            containerColor = containerColor, contentColor = contentColor
         )
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -180,8 +178,7 @@ fun AnswerButtonsPreview_ShowAnswer() {
             onEasy = {},
             nextTimes = emptyList(),
             typedAnswer = "Some answer",
-            onTypedAnswerChanged = {}
-        )
+            onTypedAnswerChanged = {})
     }
 }
 
@@ -199,7 +196,6 @@ fun AnswerButtonsPreview_EaseButtons() {
             onEasy = {},
             nextTimes = listOf("<10m", "2d", "3d", "4d"),
             typedAnswer = "",
-            onTypedAnswerChanged = {}
-        )
+            onTypedAnswerChanged = {})
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
-import com.ichi2.anki.ui.compose.theme.LocalAnkiColors
 
 @Composable
 fun AnswerButtons(
@@ -73,20 +72,21 @@ fun AnswerButtons(
     }
 }
 
+import androidx.compose.material3.MaterialTheme
+
 @Composable
 fun ShowAnswerButton(
     onShowAnswer: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val ankiColors = LocalAnkiColors.current
     Button(
         onClick = onShowAnswer,
         modifier = modifier
             .fillMaxWidth()
             .height(48.dp),
         colors = ButtonDefaults.buttonColors(
-            containerColor = ankiColors.goodButton,
-            contentColor = Color.White
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
         )
     ) {
         Text("Show Answer")
@@ -102,15 +102,42 @@ fun EaseButtons(
     nextTimes: List<String>,
     modifier: Modifier = Modifier
 ) {
-    val ankiColors = LocalAnkiColors.current
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        EaseButton(label = "Again", nextTime = nextTimes.getOrNull(0) ?: "", onClick = onAgain, color = ankiColors.againButton, modifier = Modifier.weight(1f))
-        EaseButton(label = "Hard", nextTime = nextTimes.getOrNull(1) ?: "", onClick = onHard, color = ankiColors.hardButton, modifier = Modifier.weight(1f))
-        EaseButton(label = "Good", nextTime = nextTimes.getOrNull(2) ?: "", onClick = onGood, color = ankiColors.goodButton, modifier = Modifier.weight(1f))
-        EaseButton(label = "Easy", nextTime = nextTimes.getOrNull(3) ?: "", onClick = onEasy, color = ankiColors.easyButton, modifier = Modifier.weight(1f))
+        EaseButton(
+            label = "Again",
+            nextTime = nextTimes.getOrNull(0) ?: "",
+            onClick = onAgain,
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+            modifier = Modifier.weight(1f)
+        )
+        EaseButton(
+            label = "Hard",
+            nextTime = nextTimes.getOrNull(1) ?: "",
+            onClick = onHard,
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.weight(1f)
+        )
+        EaseButton(
+            label = "Good",
+            nextTime = nextTimes.getOrNull(2) ?: "",
+            onClick = onGood,
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.weight(1f)
+        )
+        EaseButton(
+            label = "Easy",
+            nextTime = nextTimes.getOrNull(3) ?: "",
+            onClick = onEasy,
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            modifier = Modifier.weight(1f)
+        )
     }
 }
 
@@ -119,7 +146,8 @@ fun EaseButton(
     label: String,
     nextTime: String,
     onClick: () -> Unit,
-    color: Color,
+    containerColor: Color,
+    contentColor: Color,
     modifier: Modifier = Modifier
 ) {
     Button(
@@ -127,8 +155,8 @@ fun EaseButton(
         modifier = modifier
             .height(64.dp),
         colors = ButtonDefaults.buttonColors(
-            containerColor = color,
-            contentColor = Color.White
+            containerColor = containerColor,
+            contentColor = contentColor
         )
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
-import com.ichi2.anki.ui.compose.theme.LocalAnkiColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,7 +77,7 @@ fun ReviewerTopBar(
             text = timer, fontSize = 14.sp, modifier = Modifier.padding(end = 8.dp)
         )
     }, colors = TopAppBarDefaults.topAppBarColors(
-        containerColor = MaterialTheme.colorScheme.surface,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
         navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
         titleContentColor = MaterialTheme.colorScheme.onSurface,
         actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -133,13 +132,12 @@ fun FlagIcon(currentFlag: Int, onSetFlag: (Int) -> Unit) {
 
 @Composable
 fun Counts(newCount: Int, learnCount: Int, reviewCount: Int, modifier: Modifier = Modifier) {
-    val ankiColors = LocalAnkiColors.current
     Row(modifier = modifier) {
         Text(
             buildAnnotatedString {
                 withStyle(
                     style = SpanStyle(
-                        color = ankiColors.newCount,
+                        color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.Bold
                     )
                 ) {
@@ -148,7 +146,7 @@ fun Counts(newCount: Int, learnCount: Int, reviewCount: Int, modifier: Modifier 
                 append(" ")
                 withStyle(
                     style = SpanStyle(
-                        color = ankiColors.learnCount,
+                        color = MaterialTheme.colorScheme.error,
                         fontWeight = FontWeight.Bold
                     )
                 ) {
@@ -157,7 +155,7 @@ fun Counts(newCount: Int, learnCount: Int, reviewCount: Int, modifier: Modifier 
                 append(" ")
                 withStyle(
                     style = SpanStyle(
-                        color = ankiColors.reviewCount,
+                        color = MaterialTheme.colorScheme.secondary,
                         fontWeight = FontWeight.Bold
                     )
                 ) {


### PR DESCRIPTION
The Reviewer UI was not using the application's dynamic theming, resulting in a disconnected and inconsistent user experience. This was caused by the use of a custom color provider (`LocalAnkiColors`) that sourced its colors from legacy XML theme attributes, which are not updated with Material You's dynamic colors.

This commit refactors the Reviewer's composables to use `MaterialTheme.colorScheme` for all color definitions. By using semantic color roles (e.g., `primary`, `errorContainer`, `surfaceContainer`), the UI now correctly adapts to the user's system-wide theme.

The following changes were made:
- Updated `ReviewerTopBar.kt` to use `MaterialTheme.colorScheme` for the top app bar background and count colors.
- Updated `AnswerButtons.kt` to use semantic container colors from `MaterialTheme.colorScheme` for the answer buttons.
- Removed the now-unused `LocalAnkiColors` provider and its usages.
- Simplified the theme application in `Reviewer.kt` by using a direct import for `AnkiDroidTheme`.