### PR TITLE
feat: Use dynamic surface color for WebView background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1028,7 +1028,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
             isFocusableInTouchMode = typeAnswer!!.useInputTag
             isScrollbarFadingEnabled = true
             // Set transparent color to prevent flashing white when night mode enabled
-            setBackgroundColor(Color.argb(1, 0, 0, 0))
+            setBackgroundColor(Themes.getColorFromAttr(this@AbstractFlashcardViewer, R.attr.colorSurface))
             CardViewerWebClient(resourceHandler, this@AbstractFlashcardViewer).apply {
                 webViewClient = this
                 this@AbstractFlashcardViewer.webViewClient = this


### PR DESCRIPTION
Uses the material theme's `colorSurface` for the WebView background color.

This ensures that the WebView background matches the rest of the app's theme, especially when using dynamic colors.
