### PR TITLE
Fix snackbar being obscured by FAB menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -379,26 +379,28 @@ fun DeckPickerScreen(
                 )
             }
         ) { paddingValues ->
-            DeckPickerContent(
-                decks = decks,
-                isRefreshing = isRefreshing,
-                onRefresh = onRefresh,
-                backgroundImage = backgroundImage,
-                onDeckClick = onDeckClick,
-                onExpandClick = onExpandClick,
-                onDeckOptions = onDeckOptions,
-                onRename = onRename,
-                onExport = onExport,
-                onDelete = onDelete,
-                onRebuild = onRebuild,
-                onEmpty = onEmpty,
-                listState = listState,
-                contentPadding = paddingValues,
-            )
+            Box(modifier = Modifier.fillMaxSize()) {
+                DeckPickerContent(
+                    decks = decks,
+                    isRefreshing = isRefreshing,
+                    onRefresh = onRefresh,
+                    backgroundImage = backgroundImage,
+                    onDeckClick = onDeckClick,
+                    onExpandClick = onExpandClick,
+                    onDeckOptions = onDeckOptions,
+                    onRename = onRename,
+                    onExport = onExport,
+                    onDelete = onDelete,
+                    onRebuild = onRebuild,
+                    onEmpty = onEmpty,
+                    listState = listState,
+                    contentPadding = paddingValues,
+                )
+                Scrim(
+                    visible = fabMenuExpanded, onDismiss = { onFabMenuExpandedChange(false) }
+                )
+            }
         }
-        Scrim(
-            visible = fabMenuExpanded, onDismiss = { onFabMenuExpandedChange(false) }
-        )
         BackHandler(fabMenuExpanded) { onFabMenuExpandedChange(false) }
     }
 }


### PR DESCRIPTION
The snackbar on the DeckPicker screen was being displayed underneath the floating action button (FAB) menu. This was caused by the `ExpandableFabContainer` being placed outside the `Scaffold`, which caused it to render on top of the snackbar.

To fix this, the `ExpandableFab` is moved into the `Scaffold`'s `floatingActionButton` slot. The `Scaffold` now correctly manages the layout, ensuring the snackbar is displayed above the FAB as intended. The redundant `ExpandableFabContainer` has been removed.
