### PR TITLE
feat: Add sync button with dynamic badge to top app bar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerModels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerModels.kt
@@ -27,4 +27,11 @@ sealed class DeckSelectionResult {
     object NoCardsToStudy : DeckSelectionResult()
 }
 
+enum class SyncIconState {
+    Normal,
+    PendingChanges,
+    OneWay,
+    NotLoggedIn,
+}
+
 fun DeckNode.onlyHasDefaultDeck() = children.singleOrNull()?.did == Consts.DEFAULT_DECK_ID

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/AnkiDroidApp.kt
@@ -33,6 +33,8 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -71,6 +73,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ichi2.anki.R
 import com.ichi2.anki.deckpicker.DisplayDeckNode
+import com.ichi2.anki.deckpicker.SyncIconState
 
 // Define Expressive Typography
 val GoogleSansRounded = FontFamily(
@@ -227,6 +230,8 @@ fun AnkiDroidApp(
     requestSearchFocus: Boolean,
     onSearchFocusRequested: () -> Unit,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    syncIconState: SyncIconState,
+    onSync: () -> Unit,
 ) {
     val searchFocusRequester = remember {
         androidx.compose.ui.focus.FocusRequester()
@@ -301,6 +306,24 @@ fun AnkiDroidApp(
                                         Icons.Default.Search,
                                         contentDescription = stringResource(R.string.search_decks),
                                     )
+                                }
+                                BadgedBox(
+                                    badge = {
+                                        when (syncIconState) {
+                                            SyncIconState.PendingChanges -> Badge()
+                                            SyncIconState.OneWay, SyncIconState.NotLoggedIn -> Badge {
+                                                Text("!")
+                                            }
+                                            else -> {}
+                                        }
+                                    },
+                                ) {
+                                    IconButton(onClick = onSync) {
+                                        Icon(
+                                            painterResource(R.drawable.ic_sync_24dp),
+                                            contentDescription = stringResource(R.string.sync_now),
+                                        )
+                                    }
                                 }
                             }
                             if (studyOptionsData != null) {
@@ -465,6 +488,9 @@ fun AnkiDroidApp(
             onEmpty = onEmpty,
             onNavigationIconClick = onNavigationIconClick,
             fabMenuExpanded = fabMenuExpanded,
-            onFabMenuExpandedChange = { fabMenuExpanded = it })
+            onFabMenuExpandedChange = { fabMenuExpanded = it },
+            syncIconState = syncIconState,
+            onSync = onSync,
+        )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -80,6 +82,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
@@ -89,6 +92,7 @@ import androidx.graphics.shapes.Morph
 import androidx.graphics.shapes.toPath
 import com.ichi2.anki.R
 import com.ichi2.anki.deckpicker.DisplayDeckNode
+import com.ichi2.anki.deckpicker.SyncIconState
 
 private val expandedDeckCardRadius = 24.dp
 private val collapsedDeckCardRadius = 70.dp
@@ -293,7 +297,9 @@ fun DeckPickerScreen(
     searchFocusRequester: FocusRequester = FocusRequester(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     fabMenuExpanded: Boolean,
-    onFabMenuExpandedChange: (Boolean) -> Unit
+    onFabMenuExpandedChange: (Boolean) -> Unit,
+    syncIconState: SyncIconState,
+    onSync: () -> Unit,
 ) {
     var isSearchOpen by remember { mutableStateOf(false) }
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
@@ -356,6 +362,24 @@ fun DeckPickerScreen(
                                     Icons.Default.Search,
                                     contentDescription = stringResource(R.string.search_decks)
                                 )
+                            }
+                            BadgedBox(
+                                badge = {
+                                    when (syncIconState) {
+                                        SyncIconState.PendingChanges -> Badge()
+                                        SyncIconState.OneWay, SyncIconState.NotLoggedIn -> Badge {
+                                            Text("!")
+                                        }
+                                        else -> {}
+                                    }
+                                },
+                            ) {
+                                IconButton(onClick = onSync) {
+                                    Icon(
+                                        painterResource(R.drawable.ic_sync_24dp),
+                                        contentDescription = stringResource(R.string.sync_now),
+                                    )
+                                }
                             }
                         }
                     },
@@ -446,5 +470,8 @@ fun DeckPickerScreenPreview() {
         onEmpty = {},
         onNavigationIconClick = {},
         fabMenuExpanded = false,
-        onFabMenuExpandedChange = {})
+        onFabMenuExpandedChange = {},
+        syncIconState = SyncIconState.Normal,
+        onSync = {},
+    )
 }


### PR DESCRIPTION
This commit adds a sync button with a dynamic badge to the top app bar of the DeckPicker screen. The badge's appearance changes based on the sync status, providing users with clear visual feedback.

- Refactored sync logic from `DeckPicker` to `DeckPickerViewModel` to follow MVVM best practices.
- Added a `syncIconState` `StateFlow` to the `ViewModel` to expose the sync status to the UI.
- Implemented a `BadgedBox` with an `IconButton` for the sync action in both the phone and tablet layouts.
- The badge now displays a dot for pending changes and a "!" for one-way syncs or when not logged in, with appropriate colors.
- Removed the old XML-based menu item for the sync icon.

