### PR TITLE
Shaped counts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -227,7 +227,7 @@ fun DeckItem(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
                     contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                 ),
-                shape = RoundedCornerShape(SubDeckCardRadius),
+          //      shape = RoundedCornerShape(SubDeckCardRadius),
                 elevation = CardDefaults.cardElevation(0.dp)
             ) {
                 content()
@@ -239,7 +239,7 @@ fun DeckItem(
                 modifier = modifier
                     .fillMaxWidth()
                     .padding(start = ((deck.depth - 1) * 16 + 8).dp, top = 2.dp, bottom = 2.dp)
-                    .clip(RoundedCornerShape(SubDeckCardRadius))
+                 //   .clip(RoundedCornerShape(SubDeckCardRadius))
                     .background(MaterialTheme.colorScheme.surfaceContainerHigh),
             ) {
                 content()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.ui.compose
 
 import android.graphics.Matrix
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -55,6 +56,7 @@ import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -117,6 +119,8 @@ fun DeckItem(
                     .weight(1f)
                     .padding(vertical = 12.dp, horizontal = 8.dp),
                 style = if (deck.depth == 0) MaterialTheme.typography.titleLargeEmphasized else MaterialTheme.typography.titleMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
             Row(
                 modifier = Modifier.height(70.dp),
@@ -265,10 +269,9 @@ fun CardCountsContainer(
 ) {
     Box(
         modifier = Modifier
-            .size(30.dp)
+            .size(36.dp)
             .clip(shape)
-            .background(MaterialTheme.colorScheme.primaryContainer)
-            .zIndex(1F),
+            .background(MaterialTheme.colorScheme.primaryContainer),
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -132,15 +132,11 @@ fun DeckItem(
                     labelText = "New",
                     shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf)
                 )
-                CardCountsContainer(
-                    cardCount = deck.lrnCount,
-                    labelText = "Learn",
-                    shape = RoundedPolygonShape(MaterialShapes.Ghostish)
-                )
+
                 CardCountsContainer(
                     cardCount = deck.revCount,
                     labelText = "Review",
-                    shape = RoundedPolygonShape(MaterialShapes.Flower)
+                    shape = RoundedPolygonShape(MaterialShapes.Ghostish)
                 )
             }
 
@@ -271,12 +267,12 @@ fun CardCountsContainer(
         modifier = Modifier
             .size(36.dp)
             .clip(shape)
-            .background(MaterialTheme.colorScheme.primaryContainer),
+            .background(MaterialTheme.colorScheme.secondary),
         contentAlignment = Alignment.Center
     ) {
         Text(
             text = cardCount.toString(),
-            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            color = MaterialTheme.colorScheme.onSecondary,
             style = MaterialTheme.typography.labelSmall,
             modifier = Modifier.padding(0.dp)
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -20,7 +20,7 @@ package com.ichi2.anki.ui.compose
 import android.graphics.Matrix
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -36,9 +36,9 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,13 +48,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asComposePath
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -62,7 +60,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.graphics.shapes.RoundedPolygon
 import androidx.graphics.shapes.toPath
 import com.ichi2.anki.R
@@ -83,7 +80,7 @@ internal class RoundedPolygonShape(private val polygon: RoundedPolygon) : Shape 
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun DeckItem(
     deck: DisplayDeckNode,
@@ -104,13 +101,11 @@ fun DeckItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp)
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = { onDeckClick() },
-                        onLongPress = { isContextMenuOpen = true },
-                    )
-                },
+                .combinedClickable(
+                    onClick = { onDeckClick() },
+                    onLongClick = { isContextMenuOpen = true }
+                )
+                .padding(horizontal = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
 
@@ -124,51 +119,42 @@ fun DeckItem(
                 overflow = TextOverflow.Ellipsis,
             )
             Row(
-                modifier = Modifier.height(70.dp).padding(horizontal = 6.dp),
+                modifier = Modifier
+                    .height(70.dp)
+                    .padding(horizontal = 2.dp),
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 CardCountsContainer(
                     cardCount = deck.newCount,
-                    labelText = "New",
                     shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf),
                     containerColor = MaterialTheme.colorScheme.secondaryFixedDim,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryFixedVariant
                 )
 
                 CardCountsContainer(
                     cardCount = deck.revCount,
-                    labelText = "Review",
                     shape = RoundedPolygonShape(MaterialShapes.Ghostish),
                     containerColor = MaterialTheme.colorScheme.secondary,
-                    contentColor = MaterialTheme.colorScheme.onSecondary
                 )
             }
 
 
             if (deck.canCollapse) {
-                Surface(
+                IconButton(
+                    onClick = { onExpandClick() },
                     modifier = Modifier
                         .padding(start = 8.dp)
                         .size(36.dp)
-                        .clipToBounds()
-                        .pointerInput(Unit) {
-                            detectTapGestures(onTap = { onExpandClick() })
-                        },
-                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    color = MaterialTheme.colorScheme.surfaceDim,
-                    shape = MaterialTheme.shapes.extraLarge,
                 ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            painter = painterResource(
-                                if (deck.collapsed) R.drawable.ic_expand_more_black_24dp else R.drawable.ic_expand_less_black_24dp,
-                            ),
-                            contentDescription = if (deck.collapsed) stringResource(R.string.expand) else stringResource(
-                                R.string.collapse
-                            ),
-                        )
-                    }
+                    Icon(
+                        painter = painterResource(
+                            if (deck.collapsed) R.drawable.ic_expand_more_black_24dp else R.drawable.ic_expand_less_black_24dp,
+                        ),
+                        contentDescription = if (deck.collapsed) stringResource(R.string.expand) else stringResource(
+                            R.string.collapse
+                        ),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             } else {
                 Spacer(modifier = Modifier.size(44.dp))
@@ -266,12 +252,9 @@ fun DeckItem(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CardCountsContainer(
-    modifier: Modifier = Modifier,
     cardCount: Int,
-    labelText: String,
     shape: Shape,
     containerColor: Color = MaterialTheme.colorScheme.secondary,
-    contentColor: Color = MaterialTheme.colorScheme.onSecondary,
 ) {
     Box(
         modifier = Modifier
@@ -297,6 +280,6 @@ fun CardCountsContainer(
 @Composable
 fun CardCountsContainerPreview() {
     CardCountsContainer(
-        cardCount = 10, labelText = "New", shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf)
+        cardCount = 10, shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf)
     )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -67,7 +67,7 @@ import androidx.graphics.shapes.toPath
 import com.ichi2.anki.R
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 
-private val expandedDeckCardRadius = 24.dp
+private val expandedDeckCardRadius = 14.dp
 private val collapsedDeckCardRadius = 70.dp
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asComposePath
@@ -123,20 +124,24 @@ fun DeckItem(
                 overflow = TextOverflow.Ellipsis,
             )
             Row(
-                modifier = Modifier.height(70.dp),
+                modifier = Modifier.height(70.dp).padding(horizontal = 6.dp),
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 CardCountsContainer(
                     cardCount = deck.newCount,
                     labelText = "New",
-                    shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf)
+                    shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf),
+                    containerColor = MaterialTheme.colorScheme.secondaryFixedDim,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryFixedVariant
                 )
 
                 CardCountsContainer(
                     cardCount = deck.revCount,
                     labelText = "Review",
-                    shape = RoundedPolygonShape(MaterialShapes.Ghostish)
+                    shape = RoundedPolygonShape(MaterialShapes.Ghostish),
+                    containerColor = MaterialTheme.colorScheme.secondary,
+                    contentColor = MaterialTheme.colorScheme.onSecondary
                 )
             }
 
@@ -261,20 +266,27 @@ fun DeckItem(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CardCountsContainer(
-    modifier: Modifier = Modifier, cardCount: Int, labelText: String, shape: Shape
+    modifier: Modifier = Modifier,
+    cardCount: Int,
+    labelText: String,
+    shape: Shape,
+    containerColor: Color = MaterialTheme.colorScheme.secondary,
+    contentColor: Color = MaterialTheme.colorScheme.onSecondary,
 ) {
     Box(
         modifier = Modifier
             .size(36.dp)
             .clip(shape)
-            .background(MaterialTheme.colorScheme.secondary),
+            .background(containerColor),
         contentAlignment = Alignment.Center
     ) {
         Text(
             text = cardCount.toString(),
             color = MaterialTheme.colorScheme.onSecondary,
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(0.dp)
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier
+                .padding(0.dp)
+                .basicMarquee()
         )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -30,8 +29,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -100,7 +97,7 @@ fun DeckItem(
     var isContextMenuOpen by remember { mutableStateOf(false) }
 
     val content = @Composable {
-        Row {
+
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -113,33 +110,37 @@ fun DeckItem(
                 },
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column(Modifier.height(100.dp)) {
-                Text(
-                    text = deck.lastDeckNameComponent,
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(vertical = 12.dp, horizontal = 8.dp),
-                    style = if (deck.depth == 0) MaterialTheme.typography.titleLargeEmphasized else MaterialTheme.typography.titleMedium,
+
+            Text(
+                text = deck.lastDeckNameComponent,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 12.dp, horizontal = 8.dp),
+                style = if (deck.depth == 0) MaterialTheme.typography.titleLargeEmphasized else MaterialTheme.typography.titleMedium,
+            )
+            Row(
+                modifier = Modifier.height(70.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                CardCountsContainer(
+                    cardCount = deck.newCount,
+                    labelText = "New",
+                    shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf)
                 )
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    CardCountsContainer(
-                        cardCount = deck.newCount,
-                        labelText = "New",
-                        shape = RoundedPolygonShape(MaterialShapes.Clover4Leaf)
-                    )
-                    CardCountsContainer(
-                        cardCount = deck.lrnCount,
-                        labelText = "Learn",
-                        shape = RoundedPolygonShape(MaterialShapes.Ghostish)
-                    )
-                    CardCountsContainer(
-                        cardCount = deck.revCount,
-                        labelText = "Review",
-                        shape = RoundedPolygonShape(MaterialShapes.Flower)
-                    )
-                }
+                CardCountsContainer(
+                    cardCount = deck.lrnCount,
+                    labelText = "Learn",
+                    shape = RoundedPolygonShape(MaterialShapes.Ghostish)
+                )
+                CardCountsContainer(
+                    cardCount = deck.revCount,
+                    labelText = "Review",
+                    shape = RoundedPolygonShape(MaterialShapes.Flower)
+                )
             }
-            Spacer(Modifier.weight(1f))
+
+
             if (deck.canCollapse) {
                 Surface(
                     modifier = Modifier
@@ -164,7 +165,8 @@ fun DeckItem(
                         )
                     }
                 }
-
+            } else {
+                Spacer(modifier = Modifier.size(44.dp))
             }
             DropdownMenu(
                 expanded = isContextMenuOpen,
@@ -217,7 +219,7 @@ fun DeckItem(
                 )
             }
         }
-    }}
+    }
 
 
     when (deck.depth) {
@@ -245,7 +247,9 @@ fun DeckItem(
             Box(
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(start = 8.dp)
+                    .padding(start = ((deck.depth - 1) * 16 + 8).dp, top = 2.dp, bottom = 2.dp)
+                    .clip(RoundedCornerShape(SubDeckCardRadius))
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
             ) {
                 content()
             }
@@ -259,32 +263,20 @@ fun DeckItem(
 fun CardCountsContainer(
     modifier: Modifier = Modifier, cardCount: Int, labelText: String, shape: Shape
 ) {
-
-    BadgedBox(badge = {
-        Badge(
-            modifier = Modifier.zIndex(10F),
-            containerColor = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary,
-        ) {
-            Text(text = labelText, style = MaterialTheme.typography.labelSmall)
-        }
-    }) {
-        Box(
-            modifier = Modifier
-                .size(30.dp)
-                .clip(shape)
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .zIndex(1F),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = cardCount.toString(),
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                style = MaterialTheme.typography.labelSmall,
-                modifier = Modifier.padding(0.dp)
-            )
-        }
-
+    Box(
+        modifier = Modifier
+            .size(30.dp)
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.primaryContainer)
+            .zIndex(1F),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = cardCount.toString(),
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(0.dp)
+        )
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckItem.kt
@@ -18,6 +18,7 @@
 package com.ichi2.anki.ui.compose
 
 import android.graphics.Matrix
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.combinedClickable
@@ -39,6 +40,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.motionScheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -65,7 +67,8 @@ import androidx.graphics.shapes.toPath
 import com.ichi2.anki.R
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 
-private val SubDeckCardRadius = 14.dp
+private val expandedDeckCardRadius = 24.dp
+private val collapsedDeckCardRadius = 70.dp
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 internal class RoundedPolygonShape(private val polygon: RoundedPolygon) : Shape {
@@ -96,8 +99,12 @@ fun DeckItem(
 ) {
     var isContextMenuOpen by remember { mutableStateOf(false) }
 
-    val content = @Composable {
+    val cornerRadius by animateDpAsState(
+        targetValue = if (!deck.collapsed && deck.canCollapse) expandedDeckCardRadius else collapsedDeckCardRadius,
+        animationSpec = motionScheme.defaultEffectsSpec()
+    )
 
+    val content = @Composable {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -227,7 +234,7 @@ fun DeckItem(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
                     contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                 ),
-          //      shape = RoundedCornerShape(SubDeckCardRadius),
+                shape = RoundedCornerShape(cornerRadius),
                 elevation = CardDefaults.cardElevation(0.dp)
             ) {
                 content()
@@ -238,8 +245,8 @@ fun DeckItem(
             Box(
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(start = ((deck.depth - 1) * 16 + 8).dp, top = 2.dp, bottom = 2.dp)
-                 //   .clip(RoundedCornerShape(SubDeckCardRadius))
+                    .padding(top = 2.dp, bottom = 2.dp)
+                   .clip(RoundedCornerShape(cornerRadius))
                     .background(MaterialTheme.colorScheme.surfaceContainerHigh),
             ) {
                 content()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -185,15 +184,14 @@ private fun RenderDeck(
                 contentColor = MaterialTheme.colorScheme.onSurface
             )
         ) {
-            Column {
+            Column(Modifier.padding(8.dp)) {
                 content()
             }
         }
     } else {
         Column(
             modifier = Modifier.padding(
-                start = if (deck.depth == 1) 8.dp else subDeckPadding,
-                end = if (deck.depth == 1) 8.dp else 0.dp
+                start = if (deck.depth == 1) 0.dp else subDeckPadding,
             )
         ) {
             content()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.Morph
@@ -92,6 +93,7 @@ import com.ichi2.anki.deckpicker.DisplayDeckNode
 
 private val expandedDeckCardRadius = 24.dp
 private val collapsedDeckCardRadius = 70.dp
+private val subDeckPadding = 8.dp
 
 private class MorphShape(
     private val morph: Morph, private val percentage: Float
@@ -128,17 +130,20 @@ private fun RenderDeck(
         targetValue = if (!deck.collapsed && deck.canCollapse) expandedDeckCardRadius else collapsedDeckCardRadius,
         animationSpec = motionScheme.defaultEffectsSpec()
     )
+
+    val startPadding = subDeckPadding * (deck.depth)
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 2.dp),
+            .padding(start = startPadding, top = 2.dp, bottom = 2.dp),
         shape = RoundedCornerShape(cornerRadius),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
             contentColor = MaterialTheme.colorScheme.onSurface
         )
     ) {
-        Column(modifier = Modifier.padding(0.dp)) {
+        Column(modifier = Modifier.padding(end = if (deck.depth == 0) 8.dp else 0.dp)) {
             DeckItem(
                 deck = deck,
                 onDeckClick = { onDeckClick(deck) },
@@ -268,7 +273,7 @@ fun DeckPickerContent(
                 }
             }) {
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
                 contentPadding = contentPadding,
                 state = listState
             ) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/DeckPickerScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -83,7 +84,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.Morph
@@ -136,14 +136,21 @@ private fun RenderDeck(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = startPadding, top = 2.dp, bottom = 2.dp),
-        shape = RoundedCornerShape(cornerRadius),
-        colors = CardDefaults.cardColors(
+            .padding(
+                start = startPadding,
+                bottom = if (deck.depth == 0) 4.dp else 0.dp
+            ), shape = RoundedCornerShape(cornerRadius), colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
             contentColor = MaterialTheme.colorScheme.onSurface
         )
     ) {
-        Column(modifier = Modifier.padding(end = if (deck.depth == 0) 8.dp else 0.dp)) {
+        Column(
+            modifier = Modifier.padding(
+                end = if (deck.depth == 0) 8.dp else 0.dp,
+                top = if (deck.depth == 0) 6.dp else 0.dp,
+                bottom = if (deck.depth == 0) 6.dp else 0.dp
+            ), verticalArrangement = Arrangement.Center
+        ) {
             DeckItem(
                 deck = deck,
                 onDeckClick = { onDeckClick(deck) },
@@ -273,7 +280,9 @@ fun DeckPickerContent(
                 }
             }) {
             LazyColumn(
-                modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 8.dp),
                 contentPadding = contentPadding,
                 state = listState
             ) {


### PR DESCRIPTION
This pull request refactors and enhances the deck picker UI in AnkiDroid's Compose implementation, focusing on improved visual presentation, code organization, and scalability for nested decks. The changes introduce a new `RenderDeck` composable for recursive deck rendering, update the deck item UI to use custom shapes and animated transitions, and streamline deck tree construction for better handling of parent-child relationships.

### Deck tree construction and recursive rendering

* Added logic to build a parent-to-children map for decks and refactored the deck rendering to use a new recursive `RenderDeck` composable, allowing for proper display and animation of nested decks. (`DeckPickerScreen.kt`) [[1]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdR232-R249) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdR113-R202) [[3]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdL177-L268)

### UI improvements and custom shapes

* Updated the deck item presentation to use animated corner radius and custom shapes (via `RoundedPolygonShape`), and replaced the previous card count display with visually distinct containers for new and review counts using Material shapes. (`DeckItem.kt`) [[1]](diffhunk://#diff-61751cdda0af03a62e47ed580af738dda5d6f451f11d708a8b48e8f543e45594R102-R167) [[2]](diffhunk://#diff-61751cdda0af03a62e47ed580af738dda5d6f451f11d708a8b48e8f543e45594L212-R292) [[3]](diffhunk://#diff-61751cdda0af03a62e47ed580af738dda5d6f451f11d708a8b48e8f543e45594L43-R86) [[4]](diffhunk://#diff-61751cdda0af03a62e47ed580af738dda5d6f451f11d708a8b48e8f543e45594R40-R43)

### Code organization and maintainability

* Removed duplicated logic for rendering decks and sub-decks, consolidating it into the new recursive component and simplifying the main deck picker content. (`DeckPickerScreen.kt`)

### Minor enhancements

* Added preview composable for card count containers and improved text overflow handling in deck names for better UI robustness. (`DeckItem.kt`)

### Theming and animation

* Applied animated transitions for deck expansion/collapse and updated usage of Material motion schemes for consistent effects. (`DeckPickerScreen.kt`, `DeckItem.kt`) [[1]](diffhunk://#diff-61751cdda0af03a62e47ed580af738dda5d6f451f11d708a8b48e8f543e45594R102-R167) [[2]](diffhunk://#diff-1ade381bbe6eb4a5730a74a27eb6f4f310692233ec285e44e58bbdaa8a5ad0fdR113-R202)

These changes modernize the deck picker UI and lay the groundwork for more flexible and visually appealing deck management in the app.